### PR TITLE
Added node environment to service unit

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ etherpad_console_purge_jobs:
   - "--days=365 --suffix=-keep"
   - "--days=30 --ignore-suffix=-keep --ignore-suffix=-temp"
 etherpad_console_purge_enabled: False
+etherpad_node_environment: production
 etherpad_title: "Etherpad"
 etherpad_favicon: "favicon.ico"
 etherpad_ip: 0.0.0.0

--- a/templates/etherpad-lite.service.j2
+++ b/templates/etherpad-lite.service.j2
@@ -8,6 +8,7 @@ User={{ etherpad_user }}
 Group={{ etherpad_group }}
 WorkingDirectory={{ etherpad_path }}
 ExecStart=/usr/bin/nodejs {{ etherpad_path }}/node_modules/ep_etherpad-lite/node/server.js
+Environment=NODE_ENV={{ etherpad_node_environment }}
 Restart=always
 
 [Install]


### PR DESCRIPTION
The official guides for etherpad-lite include the node environment in the service unit (https://github.com/ether/etherpad-lite/wiki/How-to-deploy-Etherpad-Lite-as-a-service). This is missing in the current ansible template. 