### PR TITLE
Make parameters for python mysql lib and node path configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -152,3 +152,9 @@ etherpad_toc_disable: "true"
 
 # Settings for plugin 'ep_auth_author'
 # etherpad_auth_author_prefix:
+
+# Change to "python3-pymysql" on python3
+etherpad_python_mysql_package: "python-mysqldb"
+
+# Change to "/usr/bin/node" on Ubuntu 20.04
+etherpad_node_path: "/usr/bin/nodejs"

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -1,7 +1,7 @@
 ---
-- name: ensure python-mysqldb is installed
+- name: ensure python mysql package is installed
   apt:
-    pkg: python-mysqldb
+    pkg: "{{ etherpad_python_mysql_package }}"
     state: present
 
 - name: ensure mysql database is present

--- a/templates/etherpad-lite.service.j2
+++ b/templates/etherpad-lite.service.j2
@@ -7,7 +7,7 @@ Type=simple
 User={{ etherpad_user }}
 Group={{ etherpad_group }}
 WorkingDirectory={{ etherpad_path }}
-ExecStart=/usr/bin/nodejs {{ etherpad_path }}/node_modules/ep_etherpad-lite/node/server.js
+ExecStart={{ etherpad_node_path }} {{ etherpad_path }}/node_modules/ep_etherpad-lite/node/server.js
 Environment=NODE_ENV={{ etherpad_node_environment }}
 Restart=always
 


### PR DESCRIPTION
When this role was run with python3 against an Ubuntu 20.04
machine, there were a couple of errors
where the code expected a different environment.
The role's python mysql package, python-mysqldb,
was specific to python 2, so was not found
when ansible was run with python 3.
The role also looked for the node binary in /usr/bin/nodejs,
but the binary on ubuntu 20.04 is in /usr/bin/node.
This commit abstracts those parameters so that the user
can input values that match their own environment.
The parameters are now {{ etherpad_python_mysql_package }}
and {{ etherpad_node_path }} .