### PR TITLE
Add configuration for plugin ep_delete_after_delay

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -140,6 +140,13 @@ etherpad_toc_disable: "true"
 # Settings for plugin 'ep_auth_author'
 # etherpad_auth_author_prefix:
 
+# Settings for plugin 'ep_delete_after_delay'
+etherpad_delete_after_delay: 86400
+etherpad_delete_after_delay_loop: true
+etherpad_delete_after_delay_loopdelay: 3600
+etherpad_delete_after_delay_deleteatstart: true
+etherpad_delete_after_delay_text: "The content of this pad has been deleted since it was older than the configured delay."
+
 # Change to "python-pymysql" on python2 systems
 etherpad_python_mysql_package: "python3-mysqldb"
 

--- a/templates/settings.json.j2
+++ b/templates/settings.json.j2
@@ -112,6 +112,15 @@
     "prefix": "{{ etherpad_auth_author_prefix }}"
   },
 {% endif %}
+{% if 'ep_delete_after_delay' in etherpad_plugins %}
+  "ep_delete_after_delay": {
+    "delay": {{ etherpad_delete_after_delay }},
+    "loop": {{ etherpad_delete_after_delay_loop|string|lower }},
+    "loopDelay": {{ etherpad_delete_after_delay_loopdelay }},
+    "deleteAtStart": {{ etherpad_delete_after_delay_deleteatstart|string|lower }},
+    "text": "{{ etherpad_delete_after_delay_text }}"
+  },
+{% endif %}
   "users": {
 {% for user in etherpad_users %}
     "{% if user.auth_author is defined and user.auth_author %}{{ etherpad_auth_author_prefix }}{% endif %}{{ user.name }}": {


### PR DESCRIPTION
We add some etherpad config inside the settings.json template to manage
ep_delete_after_delay plugin. We also add the default var to feed those
settings if it's added without defining the value for those config
options.