### PR TITLE
Force https - git protocol on github is deprecated

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,6 +90,7 @@
     name: "{{ item }}"
     path: "{{ etherpad_path }}"
     state: "{{ etherpad_plugins_state }}"
+    registry: https://github.com
   become: true
   become_user: "{{ etherpad_user }}"
   with_items: "{{ etherpad_plugins|d() }}"


### PR DESCRIPTION
We define the registry for npm tasks to https://github.com since git:// is deprecated
on github.com