### PR TITLE
Add socketio / maxHttpBufferSize conf

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,6 +86,7 @@ etherpad_automatic_reconnection_timeout: 0
 etherpad_commit_rate_limiting_duration: 1
 etherpad_commit_rate_limiting_points: 10
 etherpad_expose_version: "false"
+etherpad_socket_max_http_buffer_size: 10000
 etherpad_toolbar:
   left:
     - ["bold", "italic", "underline", "strikethrough"]

--- a/templates/settings.json.j2
+++ b/templates/settings.json.j2
@@ -169,5 +169,8 @@
     {{ appender|to_json }}
 {% endfor %}
       ]
-   }
+  },
+  "socketIo": {
+    "maxHttpBufferSize": {{ etherpad_socket_max_http_buffer_size |default(10000) }}
+  },
 }

--- a/templates/settings.json.j2
+++ b/templates/settings.json.j2
@@ -171,6 +171,6 @@
       ]
   },
   "socketIo": {
-    "maxHttpBufferSize": {{ etherpad_socket_max_http_buffer_size |default(10000) }}
+    "maxHttpBufferSize": {{ etherpad_socket_max_http_buffer_size }}
   },
 }


### PR DESCRIPTION
maxHttpBufferSize can be usefull when you host very long document within etherpad.