### PR TITLE
Fix typo in database user privileges

### DIFF
--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -44,7 +44,7 @@
     name: "{{ etherpad_mysql_database_user }}"
     state: present
     password: "{{ etherpad_mysql_database_password }}"
-    priv: "{{ etherpad_mysql_database_user }}.*:ALL"
+    priv: "{{ etherpad_mysql_database_name }}.*:ALL"
     login_unix_socket: /run/mysqld/mysqld.sock
 
 - name: Register systemd version number


### PR DESCRIPTION
This commit fixes a wrong variable name in the task that grants rights to the database user on the database. This bug only shows when the database name is set differently from the user name.