### PR TITLE
custom logo task only when var defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,7 +105,7 @@
     owner: "{{ etherpad_user }}"
     group: "{{ etherpad_group }}"
     mode: 0644
-  when: etherpad_custom_logo_src
+  when: etherpad_custom_logo_src is defined
 
 - include: abiword.yml
   when: etherpad_abiword_enabled


### PR DESCRIPTION
When the variable `etherpad_custom_logo_src` is undefined (the default), this task failed.
This patch fixes that.