### PR TITLE
Permissions on settings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
     dest: "{{ etherpad_path }}/settings.json"
     owner: "{{ etherpad_user }}"
     group: "{{ etherpad_group }}"
-    mode: 0644
+    mode: 0640
   become: true
   become_user: "{{ etherpad_user }}"
   notify: Restart etherpad-lite

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,7 @@
   become: true
   become_user: "{{ etherpad_user }}"
   notify: Restart etherpad-lite
+  no_log: true
 
 - include: redis.yml
   when: etherpad_db_type == "redis"
@@ -80,6 +81,7 @@
   become: true
   become_user: "{{ etherpad_user }}"
   notify: Restart etherpad-lite
+  no_log: true
 
 - name: Flush handlers
   meta: flush_handlers


### PR DESCRIPTION
The `settings.json` contains secrets and should likely not be world-readable. Also it should be avoided logging secrets in the ansible-logs. This PR provides patches for that.