### PR TITLE
🐛 Fix Plugin Installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,7 @@ etherpad_users: []
 etherpad_api_key: ""
 etherpad_session_key: "Y7sc5qSXw5aEBIDGsjfkyLJDV"
 etherpad_disable_ip_logging: "true"
-etherpad_default_text: '"Welcome to Etherpad!\\n\\nThis pad text is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents!\\n\\nGet involved with Etherpad at http:\\/\\/etherpad.org\\n"'
+etherpad_default_text: "Welcome to Etherpad!\\n\\nThis pad text is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents!\\n\\nGet involved with Etherpad at http:\\/\\/etherpad.org\\n"
 etherpad_pad_options_no_colors: "false"
 etherpad_pad_options_show_controls: "true"
 etherpad_pad_options_show_chat: "true"
@@ -72,7 +72,7 @@ etherpad_require_session: "false"
 etherpad_edit_only: "false"
 etherpad_minify: "true"
 etherpad_max_age: 21600
-etherpad_abiword: "{{ '\"/usr/bin/abiword\"' if etherpad_abiword_enabled else 'null' }}"
+etherpad_abiword: "{{ '/usr/bin/abiword' if etherpad_abiword_enabled else 'null' }}"
 etherpad_soffice: "null"
 etherpad_tidyhtml: "null"
 etherpad_allow_unknown_file_ends: "true"
@@ -82,7 +82,8 @@ etherpad_trust_proxy: "false"
 etherpad_cookie_same_site: "Lax"
 etherpad_cookie_session_lifetime: 864000000 # = 10d * 24h/d * 60m/h * 60s/m * 1000ms/s
 etherpad_cookie_session_refresh_interval: 864000000 # = 10d * 24h/d * 60m/h * 60s/m * 1000ms/s
-etherpad_socket_transport_protocols: ["xhr-polling", "jsonp-polling", "htmlfile"]
+etherpad_socket_transport_protocols:
+  ["xhr-polling", "jsonp-polling", "htmlfile"]
 etherpad_load_test: "false"
 etherpad_indentation_on_new_line: "false"
 etherpad_automatic_reconnection_timeout: 0
@@ -110,17 +111,15 @@ etherpad_toolbar:
     - ["timeslider_export", "timeslider_returnToPad"]
 etherpad_log_level: "INFO"
 etherpad_log_appenders:
-  -
-    type: console
+  - type: console
 #  -
 #    type: file
 #    filename: your-log-file-here.log
 #    maxLogSize: 1024
 #    backups: 3
 etherpad_abiword_enabled: False
-# list of etherpad plugins to be installed
+# List of plugins to install. Format is: { name: "ep_plugin_name", version: "0.0.0" }
 etherpad_plugins: []
-etherpad_plugins_state: present
 
 etherpad_redis_host: localhost
 etherpad_redis_port: 6379
@@ -148,7 +147,7 @@ etherpad_postgres_database_ssl_policy: "disabled"
 etherpad_mysql_systemd_dropin_enabled: False
 etherpad_mysql_systemd_dropin_service_restart: "always"
 etherpad_mysql_systemd_dropin_service_restartsec: "60"
-etherpad_mysql_systemd_dropin_unit_startlimitinterval: "60"   # in seconds
+etherpad_mysql_systemd_dropin_unit_startlimitinterval: "60" # in seconds
 etherpad_mysql_systemd_dropin_unit_startlimitburst: "10"
 
 etherpad_dirty_filename: "var/dirty.db"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,22 +4,6 @@
     name: etherpad-lite
     state: restarted
 
-- name: Ensure etherpad dependencies are latest  # noqa no-changed-when
-  command:
-    cmd: bin/installDeps.sh
-    chdir: "{{ etherpad_path }}"
-  become: true
-  become_user: "{{ etherpad_user }}"
-  notify: Fix package-lock.json # this is a hack
-
-- name: Fix package-lock.json # noqa command-instead-of-module no-changed-when
-  command:
-    cmd: git checkout src/package-lock.json
-    chdir: "{{ etherpad_path }}"
-  become: true
-  become_user: "{{ etherpad_user }}"
-  notify: Restart etherpad-lite
-
 - name: Reload systemd
   systemd:
     daemon_reload: true

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,10 +3,9 @@
   hosts: all
   become: yes
   roles:
-    - role: geerlingguy.nodejs
     - role: ansible-role-etherpad
   vars:
-    etherpad_repository_version: 1.8.13
+    etherpad_repository_version: 1.9.2
+    etherpad_plugins:
+      - { name: ep_comments_page }
     etherpad_api_key: "secure_api_key"
-    nodejs_version: 18.x
-    nodejs_install_npm_user: "root"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -4,9 +4,16 @@
   become: True
   tasks:
     - name: Run the equivalent of "apt-get update" before installing packages
-      apt:
+      ansible.builtin.apt:
         update_cache: yes
 
-    - name: install acl for ansible
-      apt:
+    - name: Install acl package
+      ansible.builtin.apt:
         pkg: acl
+
+    - name: Include NodeJS Role
+      ansible.builtin.include_role:
+        name: geerlingguy.nodejs
+      vars:
+        nodejs_version: 18.x
+        nodejs_install_npm_user: "root"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
   ansible.builtin.file:
     owner: "{{ etherpad_user }}"
     group: "{{ etherpad_user }}"
-    mode: '0700'
+    mode: "0700"
     path: "{{ etherpad_repository_key_file | dirname }}"
     state: directory
   when:
@@ -43,7 +43,8 @@
     depth: 1
   become: true
   become_user: "{{ etherpad_user }}"
-  notify: Ensure etherpad dependencies are latest
+  register: etherpad_repository
+  notify: Restart etherpad-lite
 
 - name: Ensure etherpad config is latest
   template:
@@ -72,11 +73,7 @@
     owner: root
     group: root
     mode: 0644
-
-- name: Ensure etherpad will start after system is booted
-  service:
-    name: etherpad-lite
-    enabled: yes
+  notify: Reload systemd
 
 - name: Ensure etherpad api key is latest
   template:
@@ -90,21 +87,29 @@
   notify: Restart etherpad-lite
   no_log: true
 
-- name: Flush handlers
-  meta: flush_handlers
-
-- name: Install etherpad plugins
+- name: Install etherpad plugins # noqa no-changed-when
   community.general.npm:
-    name: "{{ item }}"
+    name: "{{ item.name }}"
     path: "{{ etherpad_path }}"
-    state: "{{ etherpad_plugins_state }}"
-    registry: https://github.com
+    state: "{{ item.state | default('present') }}"
+    version: "{{ item.version | default(omit) }}"
+    registry: "{{ item.registry | default(omit) }}"
   become: true
   become_user: "{{ etherpad_user }}"
-  with_items: "{{ etherpad_plugins | default() }}"
-  notify:
-    - Ensure etherpad dependencies are latest
-    - Restart etherpad-lite
+  loop: "{{ etherpad_plugins }}"
+  register: etherpad_plugins
+  when: etherpad_plugins | length > 0
+  notify: Restart etherpad-lite
+
+- name: Install dependencies # noqa no-changed-when
+  ansible.builtin.shell: |
+    bin/installDeps.sh
+  args:
+    chdir: "{{ etherpad_path }}"
+    executable: /bin/bash
+  become: true
+  become_user: "{{ etherpad_user }}"
+  when: etherpad_repository.changed or etherpad_plugins.changed
 
 - name: Copy custom logo file if configured
   copy:
@@ -118,3 +123,9 @@
 - name: Import abiword tasks
   import_tasks: abiword.yml
   when: etherpad_abiword_enabled
+
+- name: Ensure etherpad will start after system is booted
+  service:
+    name: etherpad-lite
+    state: started
+    enabled: yes


### PR DESCRIPTION
This PR fixes #83. The plugin installation was broken because the GitHub registry was used.

Therefore, the plugins need to be installed before the dependencies. Otherwise, the `node_modules` directory will lose the link to the Etherpad sources and won't be able to start.

As an additional benefit, I removed the unnecessary fix for `package-lock.json`. It seems to be no longer necessary.