### PR TITLE
🔥 Drop Plugin Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ This variable allows to define what kind of backend storage we want to use for E
     etherpad_postgres_database_ssl_policy: "disabled"
 Those variables allow to configure Etherpad with PostgreSQL. To be able to use them, you must set the variable `etherpad_db_type` to `postgres`.
 
-    etherpad_plugins
-List of plugins we want to add to our Etherpad instance.
-
     etherpad_headerauth_username_header: x-authenticated-user
     etherpad_headerauth_displayname_header: x-authenticated-name
 Configuration values for the [ep_headerauth](https://www.npmjs.com/package/ep_headerauth) plugin (authentication with http header). If you want to use this plugin, `etherpad_trust_proxy` and `etherpad_require_authentication` must be set to True.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -118,8 +118,6 @@ etherpad_log_appenders:
 #    maxLogSize: 1024
 #    backups: 3
 etherpad_abiword_enabled: False
-# List of plugins to install. Format is: { name: "ep_plugin_name", version: "0.0.0" }
-etherpad_plugins: []
 
 etherpad_redis_host: localhost
 etherpad_redis_port: 6379
@@ -151,6 +149,9 @@ etherpad_mysql_systemd_dropin_unit_startlimitinterval: "60" # in seconds
 etherpad_mysql_systemd_dropin_unit_startlimitburst: "10"
 
 etherpad_dirty_filename: "var/dirty.db"
+
+# List of installed plugins. Will not install plugin, just indicate for settings
+etherpad_plugins: []
 
 # Settings for plugin 'ep_table_of_contents'
 etherpad_toc_disable: "true"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,6 +6,4 @@
     - role: ansible-role-etherpad
   vars:
     etherpad_repository_version: 1.9.2
-    etherpad_plugins:
-      - { name: ep_comments_page }
     etherpad_api_key: "secure_api_key"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,19 @@
   register: etherpad_repository
   notify: Restart etherpad-lite
 
+- name: Install dependencies # noqa no-handler
+  ansible.builtin.shell: |
+    bin/installDeps.sh
+  args:
+    chdir: "{{ etherpad_path }}"
+    executable: /bin/bash
+  environment:
+    ETHERPAD_PRODUCTION: "true"
+  changed_when: false
+  become: true
+  become_user: "{{ etherpad_user }}"
+  when: etherpad_repository.changed
+
 - name: Copy configuration file
   ansible.builtin.template:
     src: settings.json.j2
@@ -80,35 +93,6 @@
   become_user: "{{ etherpad_user }}"
   notify: Restart etherpad-lite
   no_log: true
-
-- name: Install etherpad plugins # noqa no-changed-when
-  community.general.npm:
-    name: "{{ item.name }}"
-    path: "{{ etherpad_path }}"
-    state: "{{ item.state | default('present') }}"
-    version: "{{ item.version | default(omit) }}"
-    registry: "{{ item.registry | default(omit) }}"
-    production: true
-    no_optional: true
-    ignore_scripts: true
-  become: true
-  become_user: "{{ etherpad_user }}"
-  loop: "{{ etherpad_plugins }}"
-  register: etherpad_plugin
-  when: etherpad_plugins | length > 0
-  notify: Restart etherpad-lite
-
-- name: Install dependencies # noqa no-changed-when
-  ansible.builtin.shell: |
-    bin/installDeps.sh
-  args:
-    chdir: "{{ etherpad_path }}"
-    executable: /bin/bash
-  environment:
-    ETHERPAD_PRODUCTION: "true"
-  become: true
-  become_user: "{{ etherpad_user }}"
-  when: etherpad_repository.changed or etherpad_plugin.changed
 
 - name: Copy custom logo file if configured
   ansible.builtin.copy:


### PR DESCRIPTION
It turns out that is not possible to maintain a consistent and reliable plugin support for Etherpad. The plugins need to be handled very special which is a pain to implement with ansible.