### PR TITLE
Set NODE_ENV when building Etherpad as variable

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,7 +7,7 @@
     executable: /bin/bash
     chdir: "{{ etherpad_path }}"
   environment:
-    NODE_ENV: "development"
+    NODE_ENV: "{{ etherpad_node_environment }}"
     PATH: "{{ etherpad_environment_path }}"
   become: true
   become_user: "{{ etherpad_user }}"


### PR DESCRIPTION
Close https://github.com/systemli/ansible-role-etherpad/issues/107